### PR TITLE
Send request with body as json (with proper headers)

### DIFF
--- a/src/custom/EchoAdaptEngine.php
+++ b/src/custom/EchoAdaptEngine.php
@@ -87,7 +87,7 @@ class EchoAdaptEngine implements CatEngine
     {
         $options = ['headers' => []];
         if (!empty($data)) {
-            $options['body'] = json_encode($data);
+            $options['json'] = $data;
         }
         $response = $this->getEchoAdaptClient()->request($method, $this->buildUrl($url), $options);
         return json_decode($response->getBody()->getContents(), true);


### PR DESCRIPTION
During the testing CAT Engine integration with a customer, we found that our code doesn't send the proper header in the request. It should contain header `Content-Type: application/javascript`. Guzzle library can add it automatically if we send body as JSON.