### PR TITLE
do not make call in case if session status is null

### DIFF
--- a/src/custom/EchoAdaptSession.php
+++ b/src/custom/EchoAdaptSession.php
@@ -66,7 +66,7 @@ class EchoAdaptSession implements CatSession
      */
     public function getTestMap($results = [])
     {
-        if (!empty($results)) {
+        if (!empty($results) && $this->sessionState !== null) {
             $data = $this->engine->call(
                 'tests/'.$this->sectionId.'/test_taker_sessions/'.$this->testTakerSessionId.'/results',
                 'POST',
@@ -87,7 +87,7 @@ class EchoAdaptSession implements CatSession
             $this->sessionState = $data['sessionState'];
         }
 
-        return $this->nextItems;
+        return is_array($this->nextItems) ? $this->nextItems : [];
     }
     
     /**


### PR DESCRIPTION
In case if test taker on the last item presses `previous` button or jumps to any previous item the last item will be submitted and in the response session status will be set to `null`.
Any further test takers move should not cause calls to the echo engine.
Related PR: https://github.com/oat-sa/extension-tao-testqti/pull/1156
