### PR TITLE
fix/fatal_error_in_case_of_failed_connect

### DIFF
--- a/src/custom/EchoAdaptEngine.php
+++ b/src/custom/EchoAdaptEngine.php
@@ -102,7 +102,7 @@ class EchoAdaptEngine implements CatEngine
             if ($response->getStatusCode() != 200) {
                 throw new CatEngineException(
                     'The CAT engine server cannot handle the request to ' . $this->buildUrl($url) .
-                    isset($options['body']) ? ' with data (' . $options['body'] . ')' : ' (No body data)'
+                    (isset($options['body']) ? ' with data (' . $options['body'] . ')' : ' (No body data)')
                 );
             }
 


### PR DESCRIPTION
In case of non 200 status code this line causes fatal error:
```
"message": "php error(8): Undefined index: body",
"code_file": "/var/www/html/tao/vendor/oat-sa/lib-test-cat/src/custom/EchoAdaptEngine.php",
"code_line": "105",
```