### PR TITLE
Feat/fun 1740/update guzzle client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
 		"GPL-2.0"
 	],
 	"require" : {
-		"php" : ">=5.3.10",
 		"guzzlehttp/guzzle" : "~7.0"
 	},
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	],
 	"require" : {
 		"php" : ">=5.3.10",
-		"guzzlehttp/guzzle" : "~6.0"
+		"guzzlehttp/guzzle" : "~7.0"
 	},
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
Update Guzzle with the 7.x

For updating Elastic Lib with the version which is support elastic search 8 we need to update guzzle as it requires in the latest version of the Elastic Lib